### PR TITLE
Fixing total_page count in BusinessLogicPagination, could not get use…

### DIFF
--- a/app/models/business_logic_pagination.rb
+++ b/app/models/business_logic_pagination.rb
@@ -17,7 +17,8 @@ class BusinessLogicPagination
   end
 
   def total_pages
-    page_result = (@resource.count.modulo(@per_page) == 0) ? ( (@resource.count / @per_page) - 1 ) : (@resource.count / @per_page)
+    resource_amount = @resource.ids.count
+    page_result = (resource_amount.modulo(@per_page) == 0) ? ( (resource_amount / @per_page) - 1 ) : (resource_amount / @per_page)
   end
 
   def display_humanized_total_pages


### PR DESCRIPTION
… modulo on hash returned in .group method from ActiveModel query, same query, counted returned ids instead of returned resource amount.